### PR TITLE
Remove 'self' kwarg in the case of a bound task

### DIFF
--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -92,6 +92,12 @@ class QueueOnce(Task):
         args = args or {}
         kwargs = kwargs or {}
         call_args = getcallargs(self.run, *args, **kwargs)
+        # Remove the task instance from the kwargs. This only happens when the
+        # task has the 'bind' attribute set to True. We remove it, as the task
+        # has a memory pointer in its repr, that will change between the task
+        # caller and the celery worker
+        if isinstance(call_args.get('self'), Task):
+            del call_args['self']
         key = queue_once_key(self.name, call_args, restrict_to)
         return key
 

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -9,6 +9,11 @@ def simple_example():
     return "simple"
 
 
+@task(name='bound_task', bind=True, base=QueueOnce)
+def bound_task(self, a, b):
+    return a + b
+
+
 @task(name='args_example', base=QueueOnce)
 def args_example(a, b):
     return a + b
@@ -33,6 +38,10 @@ def test_get_key_args_2():
 
 def test_get_key_select_args_1():
     assert "qo_select_args_example_a-1" == select_args_example.get_key(kwargs={'a':1, 'b': 2})
+
+
+def test_get_key_bound_task():
+    assert "qo_bound_task_a-1_b-2" == bound_task.get_key(kwargs={'a': 1, 'b': 2})
 
 
 @freeze_time("2012-01-14")  # 1326499200


### PR DESCRIPTION
The repr of a task contains a memory address (ex ``"<@task: sometask of package:0x7f0211153990>"``), that will differ between the task caller and the worker itself. Consequently, the lock will never get removed (until it expires) as the generated keys will differ.

By removing the repr from the lock, only the actual task arguments and keyword arguments are used.