### PR TITLE
Unify the repr of both str and unicode strings

### DIFF
--- a/celery_once/helpers.py
+++ b/celery_once/helpers.py
@@ -34,6 +34,20 @@ def now_unix():
     return int(time())
 
 
+def convert_unicode_items_to_str(l):
+    """
+    Convert every binary type item (str in python 2, bytes in python 3)
+    into text type (unicode in python 2, str in python 3).
+    """
+    for i, item in enumerate(l):
+        if six.PY2:
+            if isinstance(item, unicode):
+                l[i] = item.encode('utf-8')
+            elif isinstance(item, list):
+                item = convert_unicode_items_to_str(item)
+    return l
+
+
 def kwargs_to_list(kwargs):
     """
     Turns {'a': 1, 'b': 2} into ["a-1", "b-2"]
@@ -42,6 +56,8 @@ def kwargs_to_list(kwargs):
     # Kwargs are sorted in alphabetic order.
     # Taken from http://www.saltycrane.com/blog/2007/09/how-to-sort-python-dictionary-by-keys/
     for k, v in sorted(six.iteritems(kwargs), key=lambda kv: (str(kv[0]), str(kv[1]))):
+        if isinstance(v, list):
+            v = convert_unicode_items_to_str(v)
         kwargs_list.append(str(k) + '-' + str(v))
     return kwargs_list
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import six
+
 from celery_once.helpers import queue_once_key, kwargs_to_list
 
 
@@ -25,6 +30,20 @@ def test_kwargs_to_list_4():
     keys = kwargs_to_list(
         {'int': 1, 'boolean': True, 'str': 'abc', 'list': [1, '2']})
     assert keys == ["boolean-True", "int-1", "list-[1, '2']", "str-abc"]
+
+
+@pytest.mark.skipif(six.PY3, reason='requires python 2')
+def test_kwargs_to_list_5():
+    keys = kwargs_to_list(
+        {'int': 1, 'boolean': True, 'str': 'abc', 'list': [1, u'2']})
+    assert keys == ["boolean-True", "int-1", "list-[1, '2']", "str-abc"]
+
+
+@pytest.mark.skipif(six.PY3, reason='requires python 2')
+def test_kwargs_to_list_6():
+    keys = kwargs_to_list(
+        {'int': 1, 'boolean': True, 'str': 'abc', 'list': [1, u'hé']})
+    assert keys == ["boolean-True", "int-1", "list-[1, 'h\\xc3\\xa9']", "str-abc"]
 
 
 def test_queue_once_key():


### PR DESCRIPTION
If the task is called with a kwarg as a list of str, the serialization/deserialization step may (depending on the one used) convert it to a list unicode strings. 
The repr of the list would then differ (eg "['a', 'b']" vs "[u'a', u'b']"), leading to two different redis keys.

To solve this issue, we recursively parse every kwarg list, and encode any *python 2* unicode string into a byte string (str) using the UTF-8 codec.

Note that nothing is done for python3, as it does not use the u prefix by default.