### PR TITLE
fix return value of graceful option

### DIFF
--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from celery import Task
+from celery import Task, states
+from celery.result import EagerResult
 from inspect import getcallargs
 from .helpers import queue_once_key, get_redis, now_unix
 
@@ -80,7 +81,7 @@ class QueueOnce(Task):
             self.raise_or_lock(key, once_timeout)
         except self.AlreadyQueued as e:
             if once_graceful:
-                return None
+                return EagerResult(None, None, states.REJECTED)
             raise e
         return super(QueueOnce, self).apply_async(args, kwargs, **options)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -71,7 +71,7 @@ def test_apply_async_2(redis):
 def test_apply_async_3(redis):
     redis.set("qo_example_a-1", 10000000000)
     result = example.apply_async(args=(redis, ), once={'graceful': True})
-    assert result is None
+    assert result.result is None
 
 
 def test_apply_async_unlock_before_run_1(redis):


### PR DESCRIPTION
A small fix to prevent celery beat from crashing when graceful option is set.
`apply_async` should return an `AsyncResult` but we can't use it here so we use an `EagerResult` to emulate it.