### PR TITLE
Feature/return task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Usage
 To use ``celery_once``, your tasks need to inherit from an `abstract <http://celery.readthedocs.org/en/latest/userguide/tasks.html#abstract-classes>`_ base task called ``QueueOnce`` or ``QueueOnceId``.
 
 * ``QueueOnce``: Prevent execution of tasks of the same type and same parameters
-* ``QueueOnceId``: Prevent the execution of same tasks with same task_id (celery parameter). Arguments can be different.
+* ``QueueOnceId``: Prevent the execution of same tasks with same task_id (celery parameter). If the task_id is not passed by the user, it generates one using its parameters. Note that this will override the default celery id generation.
 
 You may need to tune the following Celery configuration options...
 
@@ -79,8 +79,6 @@ If an attempt is made to run the task again before it completes an ``AlreadyQueu
         ..
     AlreadyQueued()
 
-Note that ``some_task.delay()`` will not be supported for ``QueueOnceId`` because the id is unknown. Use ``apply_async`` instead.
-
 .. code:: python
 
     result = example.apply_async(args=(10), task_id='some_id')
@@ -111,7 +109,7 @@ Optionally, instead of raising an ``AlreadyQueued`` exception, the task can retu
         sleep(30)
         return "Done!"
 
-For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of already running task with same id. This way it will be transparent to the caller whether the task has been created or not.
+For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of already running task. This way it will be transparent to the caller whether the task has been created or not.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -128,9 +128,9 @@ For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of the r
 
 Will output:
 
-*I am running
-*Done!
-*Done!
+* I am running
+* Done!
+* Done!
 
 ``keys (QueueOnce only)``
 --------

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Optionally, instead of raising an ``AlreadyQueued`` exception, the task can retu
         sleep(30)
         return "Done!"
 
-For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of the requested it. This way it will be transparent to the caller whether the task has been created or not.
+For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of already running task with same id. This way it will be transparent to the caller whether the task has been created or not.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,7 @@ Optionally, instead of raising an ``AlreadyQueued`` exception, the task can retu
 For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of the requested it. This way it will be transparent to the caller whether the task has been created or not.
 
 .. code:: python
+
    @celery.task(base=QueueOnceId)
     def example_id():
         sleep(30)

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ Usage
 
 To use ``celery_once``, your tasks need to inherit from an `abstract <http://celery.readthedocs.org/en/latest/userguide/tasks.html#abstract-classes>`_ base task called ``QueueOnce`` or ``QueueOnceId``.
 
-* QueueOnce: Prevent execution of tasks of the same type and same parameters
-* QueueOnceId: Prevent the execution of same tasks with same task_id (celery parameter)
+* ``QueueOnce``: Prevent execution of tasks of the same type and same parameters
+* ``QueueOnceId``: Prevent the execution of same tasks with same task_id (celery parameter)
 
 You may need to tune the following Celery configuration options...
 
@@ -79,7 +79,7 @@ If an attempt is made to run the task again before it completes an ``AlreadyQueu
         ..
     AlreadyQueued()
 
-Note that some_task.delay() will not be supported for QueueOnceId because the id is unknown. Use apply_async instead.
+Note that ``some_task.delay()`` will not be supported for ``QueueOnceId`` because the id is unknown. Use ``apply_async`` instead.
 
 .. code:: python
 
@@ -111,7 +111,7 @@ Optionally, instead of raising an ``AlreadyQueued`` exception, the task can retu
         sleep(30)
         return "Done!"
 
-For QueueOnceId, you can use this option to get the AsyncResult of the requested it. This way it will be transparent to the caller whether the task has been created or not.
+For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of the requested it. This way it will be transparent to the caller whether the task has been created or not.
 
 .. code:: python
    @celery.task(base=QueueOnceId)
@@ -128,9 +128,9 @@ For QueueOnceId, you can use this option to get the AsyncResult of the requested
 
 Will output:
 
-I am running
-Done!
-Done!
+*I am running
+*Done!
+*Done!
 
 ``keys (QueueOnce only)``
 --------

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Usage
 To use ``celery_once``, your tasks need to inherit from an `abstract <http://celery.readthedocs.org/en/latest/userguide/tasks.html#abstract-classes>`_ base task called ``QueueOnce`` or ``QueueOnceId``.
 
 * ``QueueOnce``: Prevent execution of tasks of the same type and same parameters
-* ``QueueOnceId``: Prevent the execution of same tasks with same task_id (celery parameter)
+* ``QueueOnceId``: Prevent the execution of same tasks with same task_id (celery parameter). Arguments can be different.
 
 You may need to tune the following Celery configuration options...
 
@@ -117,8 +117,8 @@ For ``QueueOnceId``, you can use this option to get the ``AsyncResult`` of the r
 
    @celery.task(base=QueueOnceId)
     def example_id():
-        sleep(30)
         print("I am running")
+        sleep(30)
         return "Done!"
 
     result1 = example_id.apply(args=(10), once={'graceful': True}, task_id='some_id')

--- a/celery_once/__init__.py
+++ b/celery_once/__init__.py
@@ -5,4 +5,4 @@ __email__ = 'cam@trackmaven.com'
 __version__ = '0.1.4'
 
 
-from .tasks import QueueOnce, AlreadyQueued
+from .tasks import QueueOnce, QueueOnceId, AlreadyQueued

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -44,7 +44,7 @@ class QueueOnceBase(Task):
             self.config, "ONCE_DEFAULT_TIMEOUT", 60 * 60)
 
     def apply_async(self, args=None, kwargs=None, **options):
-        raise Exception("Cannot run abstract task")
+        raise TypeError("Cannot run abstract task")
 
     def raise_or_lock(self, key, expires):
         """

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from celery import Task, states
-from celery.result import EagerResult
+from celery.result import EagerResult, AsyncResult
 from inspect import getcallargs
 from .helpers import queue_once_key, get_redis, now_unix
 
@@ -11,7 +11,7 @@ class AlreadyQueued(Exception):
         self.countdown = countdown
 
 
-class QueueOnce(Task):
+class QueueOnceBase(Task):
     AlreadyQueued = AlreadyQueued
     once = {
         'graceful': False,
@@ -23,18 +23,7 @@ class QueueOnce(Task):
 
     An abstract tasks with the ability to detect if it has already been queued.
     When running the task (through .delay/.apply_async) it checks if the tasks
-    is not already queued. By default it will raise an
-    an AlreadyQueued exception if it is, by you can silence this by including
-    `options={'graceful': True}` in apply_async or in the task's settings.
-
-    Example:
-
-    >>> from celery_queue.tasks import QueueOnce
-    >>> from celery import task
-    >>> @task(base=QueueOnce, once={'graceful': True})
-    >>> def example(time):
-    >>>     from time import sleep
-    >>>     sleep(time)
+    is not already queued.
     """
     abstract = True
     once = {}
@@ -55,53 +44,7 @@ class QueueOnce(Task):
             self.config, "ONCE_DEFAULT_TIMEOUT", 60 * 60)
 
     def apply_async(self, args=None, kwargs=None, **options):
-        """
-        Queues a task, raises an exception by default if already queued.
-
-        :param \*args: positional arguments passed on to the task.
-        :param \*\*kwargs: keyword arguments passed on to the task.
-        :keyword \*\*once: (optional)
-            :param: graceful: (optional)
-                If True, wouldn't raise an exception if already queued.
-                Instead will return none.
-            :param: timeout: (optional)
-                An `int' number of seconds after which the lock will expire.
-                If not set, defaults to 1 hour.
-            :param: keys: (optional)
-
-        """
-        once_options = options.get('once', {})
-        once_graceful = once_options.get(
-            'graceful', self.once.get('graceful', False))
-        once_timeout = once_options.get(
-            'timeout', self.once.get('timeout', self.default_timeout))
-
-        key = self.get_key(args, kwargs)
-        try:
-            self.raise_or_lock(key, once_timeout)
-        except self.AlreadyQueued as e:
-            if once_graceful:
-                return EagerResult(None, None, states.REJECTED)
-            raise e
-        return super(QueueOnce, self).apply_async(args, kwargs, **options)
-
-    def get_key(self, args=None, kwargs=None):
-        """
-        Generate the key from the name of the task (e.g. 'tasks.example') and
-        args/kwargs.
-        """
-        restrict_to = self.once.get('keys', None)
-        args = args or {}
-        kwargs = kwargs or {}
-        call_args = getcallargs(self.run, *args, **kwargs)
-        # Remove the task instance from the kwargs. This only happens when the
-        # task has the 'bind' attribute set to True. We remove it, as the task
-        # has a memory pointer in its repr, that will change between the task
-        # caller and the celery worker
-        if isinstance(call_args.get('self'), Task):
-            del call_args['self']
-        key = queue_once_key(self.name, call_args, restrict_to)
-        return key
+        raise Exception("Cannot run abstract task")
 
     def raise_or_lock(self, key, expires):
         """
@@ -124,6 +67,26 @@ class QueueOnce(Task):
     def get_unlock_before_run(self):
         return self.once.get('unlock_before_run', False)
 
+    def clear_lock(self, key):
+        self.redis.delete(key)
+
+
+class QueueOnce(QueueOnceBase):
+    """
+    Creates a singleton task using its parameters or a subset of them.
+    By default it will raise an AlreadyQueued exception but you can silence this by including
+    `options={'graceful': True}` in apply_async or in the task's settings.
+    In that case it will return None.
+
+    Example:
+
+         from celery_queue.tasks import QueueOnce
+         from celery import task
+         @task(base=QueueOnce, once={'graceful': True})
+         def example(time):
+             from time import sleep
+            sleep(time)
+    """
     def __call__(self, *args, **kwargs):
         # Only clear the lock before the task's execution if the
         # "unlock_before_run" option is True
@@ -131,10 +94,7 @@ class QueueOnce(Task):
             key = self.get_key(args, kwargs)
             self.clear_lock(key)
 
-        return super(QueueOnce, self).__call__(*args, **kwargs)
-
-    def clear_lock(self, key):
-        self.redis.delete(key)
+        return super(QueueOnceBase, self).__call__(*args, **kwargs)
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """
@@ -146,3 +106,130 @@ class QueueOnce(Task):
         if not self.get_unlock_before_run():
             key = self.get_key(args, kwargs)
             self.clear_lock(key)
+
+    def get_key(self, args=None, kwargs=None):
+        """
+        Generate the key from the name of the task (e.g. 'tasks.example') and
+        args/kwargs.
+        """
+        restrict_to = self.once.get('keys', None)
+        args = args or {}
+        kwargs = kwargs or {}
+        call_args = getcallargs(self.run, *args, **kwargs)
+        # Remove the task instance from the kwargs. This only happens when the
+        # task has the 'bind' attribute set to True. We remove it, as the task
+        # has a memory pointer in its repr, that will change between the task
+        # caller and the celery worker
+        if isinstance(call_args.get('self'), Task):
+            del call_args['self']
+        key = queue_once_key(self.name, call_args, restrict_to)
+        return key
+
+    def apply_async(self, args=None, kwargs=None, **options):
+        """
+        Queues a task, raises an exception by default if already queued.
+
+        :param \*args: positional arguments passed on to the task.
+        :param \*\*kwargs: keyword arguments passed on to the task.
+        :keyword \*\*once: (optional)
+            :param: graceful: (optional)
+                If True, wouldn't raise an exception if already queued.
+                Instead will return none.
+            :param: timeout: (optional)
+                An `int' number of seconds after which the lock will expire.
+                If not set, defaults to 1 hour.
+            :param: unlock_before_run:
+                Remove the redis lock as soon as the task has started.
+            :param: keys: (optional)
+
+        """
+        once_options = options.get('once', {})
+        once_graceful = once_options.get(
+            'graceful', self.once.get('graceful', False))
+        once_timeout = once_options.get(
+            'timeout', self.once.get('timeout', self.default_timeout))
+
+        key = self.get_key(args, kwargs)
+        try:
+            self.raise_or_lock(key, once_timeout)
+        except self.AlreadyQueued as e:
+            if once_graceful:
+                return EagerResult(None, None, states.REJECTED)
+            raise e
+        return super(QueueOnceBase, self).apply_async(args, kwargs, **options)
+
+
+
+class QueueOnceId(QueueOnceBase):
+
+    """
+    Creates a singleton task using its id.
+    By default it will raise an AlreadyQueued exception but you can silence this by including
+    `options={'graceful': True}` in apply_async or in the task's settings.
+    In that case it will return an asynchronous result of the task_id.
+
+    Example:
+
+         from celery_queue.tasks import QueueOnceId
+         from celery import task
+         @task(base=QueueOnceId, once={'graceful': True})
+         def example(time):
+             from time import sleep
+             sleep(time)
+    """
+
+    def get_key(self, task_id):
+        """
+        Generate the key from the id of the task
+        """
+        keys = ['qo', self.name, str(task_id)]
+        return '_'.join(keys)
+
+    def apply_async(self, args=None, kwargs=None, **options):
+        """
+        Queues a task using its task_id, raises an exception by default if already queued.
+        The task_id must be set for this task type.
+
+        :param \*args: positional arguments passed on to the task.
+        :param \*\*kwargs: keyword arguments passed on to the task.
+        :keyword \*\*once: (optional)
+            :param: graceful: (optional)
+                If True, wouldn't raise an exception if already queued.
+                Instead will return AsyncResult(task_id).
+            :param: timeout: (optional)
+                An `int' number of seconds after which the lock will expire.
+                If not set, defaults to 1 hour.
+            :param: keys: (optional)
+
+        """
+        if 'task_id' not in options:
+            raise ValueError("You must select a task id in order to use QueueOnceId")
+        task_id = str(options.get('task_id'))
+
+        if task_id == '':
+            raise ValueError("You must select a task id in order to use QueueOnceId")
+
+        once_options = options.get('once', {})
+        once_graceful = once_options.get(
+            'graceful', self.once.get('graceful', False))
+        once_timeout = once_options.get(
+            'timeout', self.once.get('timeout', self.default_timeout))
+
+        key = self.get_key(task_id)
+        try:
+            self.raise_or_lock(key, once_timeout)
+        except self.AlreadyQueued as e:
+            if once_graceful:
+                return AsyncResult(options.get('task_id'))
+            raise e
+        return super(QueueOnceBase, self).apply_async(args, kwargs, **options)
+
+    def after_return(self, status, retval, task_id, args, kwargs, einfo):
+        """
+        After a task has run (both succesfully or with a failure) clear the
+        lock if "unlock_before_run" is False.
+        """
+        # Only clear the lock after the task's execution if the
+        # "unlock_before_run" option is False
+        key = self.get_key(task_id)
+        self.clear_lock(key)

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -199,7 +199,6 @@ class QueueOnceId(QueueOnceBase):
             :param: timeout: (optional)
                 An `int' number of seconds after which the lock will expire.
                 If not set, defaults to 1 hour.
-            :param: keys: (optional)
 
         """
         if 'task_id' not in options:
@@ -220,16 +219,14 @@ class QueueOnceId(QueueOnceBase):
             self.raise_or_lock(key, once_timeout)
         except self.AlreadyQueued as e:
             if once_graceful:
-                return AsyncResult(options.get('task_id'))
+                return AsyncResult(task_id)
             raise e
         return super(QueueOnceBase, self).apply_async(args, kwargs, **options)
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         """
         After a task has run (both succesfully or with a failure) clear the
-        lock if "unlock_before_run" is False.
+        lock.
         """
-        # Only clear the lock after the task's execution if the
-        # "unlock_before_run" option is False
         key = self.get_key(task_id)
         self.clear_lock(key)

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -189,6 +189,9 @@ class QueueOnceId(QueueOnceBase):
         keys = ['qo', self.name, str(task_id)]
         return '_'.join(keys)
 
+    def get_key_from_arguments(self, args, kwargs):
+        return self.__name__ + '_' + str(base64.b64encode(self.get_key(args, kwargs)).decode('ascii'))
+
     def apply_async(self, args=None, kwargs=None, **options):
         """
         Queues a task using its task_id, raises an exception by default if already queued.
@@ -207,7 +210,7 @@ class QueueOnceId(QueueOnceBase):
         """
 
         if 'task_id' not in options:
-            task_id = self.__name__ + '_' + str(base64.b64encode(self.get_key(args, kwargs).encode('utf-8')))
+            task_id = self.get_key_from_arguments(args, kwargs)
             options['task_id'] = task_id
         else:
             task_id = str(options.get('task_id'))
@@ -240,5 +243,5 @@ class QueueOnceId(QueueOnceBase):
         if self.task_id_given:
             key = self.get_key_from_id(task_id)
         else:
-            key = self.__name__ + '_' + str(base64.b64encode(self.get_key(args, kwargs).encode('utf-8')))
+            key = self.get_key_from_arguments(args, kwargs)
         self.clear_lock(key)

--- a/celery_once/tasks.py
+++ b/celery_once/tasks.py
@@ -190,7 +190,7 @@ class QueueOnceId(QueueOnceBase):
         return '_'.join(keys)
 
     def get_key_from_arguments(self, args, kwargs):
-        return self.__name__ + '_' + str(base64.b64encode(self.get_key(args, kwargs)).decode('ascii'))
+        return self.__name__ + '_' + str(base64.b64encode(self.get_key(args, kwargs).encode('utf-8')).decode('ascii'))
 
     def apply_async(self, args=None, kwargs=None, **options):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,5 +7,5 @@ import pytest
 def redis(monkeypatch):
     fake_redis = FakeStrictRedis()
     fake_redis.flushall()
-    monkeypatch.setattr("celery_once.tasks.QueueOnce.redis", fake_redis)
+    monkeypatch.setattr("celery_once.tasks.QueueOnceBase.redis", fake_redis)
     return fake_redis

--- a/tests/integration/test_integration_once_id.py
+++ b/tests/integration/test_integration_once_id.py
@@ -13,11 +13,11 @@ app.conf.CELERY_ALWAYS_EAGER = True
 
 
 @app.task(name="example", base=QueueOnceId)
-def example(redis, a=1):
+def example(a=1):
     return 'Something'
 
 @app.task(name="example_graceful", base=QueueOnceId, once={'graceful': True})
-def example_graceful(redis, a=1):
+def example_graceful(a=1):
     return 'Something'
 
 def helper_test_result(result, id='test'):
@@ -25,44 +25,38 @@ def helper_test_result(result, id='test'):
     assert isinstance(result, AsyncResult)
     assert result.id == id
 
+def test_no_id_no_args(redis):
+    result = example.apply_async(args=( ))
+    helper_test_result(result, id='example_cW9fZXhhbXBsZV9hLTE=')
+
 def test_no_id(redis):
-    try:
-        example.apply_async(args=(redis, ))
-        pytest.fail("QueueOnceId was started without a specified task_id")
-    except ValueError:
-        pass
+    result = example.apply_async(args=(2, ))
+    helper_test_result(result, id='example_cW9fZXhhbXBsZV9hLTI=')
 
 def test_empty_string_id(redis):
     try:
-        example.apply_async(args=(redis, ), task_id='')
-        pytest.fail("QueueOnceId was started without a specified task_id")
-    except ValueError:
-        pass
-
-def test_no_id_delay(redis):
-    try:
-        example.delay(redis, 1)
-        pytest.fail("QueueOnceId was started without a specified task_id")
+        example.apply_async(args=( ), task_id='')
+        pytest.fail("QueueOnceId was started with an empty task_id")
     except ValueError:
         pass
 
 def test_specified_num_id(redis):
-    result = example.apply_async(args=(redis, ), task_id=1)
+    result = example.apply_async(args=( ), task_id=1)
     helper_test_result(result, id=1)
 
 def test_specified_string_id(redis):
-    result = example.apply_async(args=(redis, ), task_id='test')
+    result = example.apply_async(args=( ), task_id='test')
     helper_test_result(result)
 
 def test_specified_id_exists(redis):
     redis.set("qo_example_graceful_test", 10000000000)
-    result = example_graceful.apply_async(args=(redis, ), task_id='test')
+    result = example_graceful.apply_async(args=( ), task_id='test')
     helper_test_result(result)
 
 def test_specified_id_exists_not_graceful(redis):
     redis.set("qo_example_test", 10000000000)
     try:
-        example.apply_async(args=(redis, ), task_id='test')
+        example.apply_async(args=( ), task_id='test')
         pytest.fail("QueueOnceId should have failed")
     except AlreadyQueued:
         pass
@@ -71,7 +65,7 @@ def test_specified_id_exists_not_graceful(redis):
 def test_apply_async_timeout_fail(redis):
     try:
         redis.set("qo_example_test", 1326499200 + 10 * 60)
-        example.apply_async(args=(redis, ), task_id='test')
+        example.apply_async(args=( ), task_id='test')
         pytest.fail("QueueOnceId should have failed")
     except AlreadyQueued:
         pass
@@ -79,11 +73,11 @@ def test_apply_async_timeout_fail(redis):
 @freeze_time("2012-01-14")  # 1326499200
 def test_apply_async_timeout(redis):
     redis.set("qo_example_test", 1326499200 - 60 * 60)
-    result = example.apply_async(args=(redis, ), task_id='test')
+    result = example.apply_async(args=( ), task_id='test')
     helper_test_result(result)
 
 @freeze_time("2012-01-14")  # 1326499200
 def test_apply_async_timeout_result(redis):
     redis.set("qo_example_graceful_test", 1326499200 + 10 * 60)
-    result = example_graceful.apply_async(args=(redis, ), task_id='test')
+    result = example_graceful.apply_async(args=( ), task_id='test')
     helper_test_result(result)

--- a/tests/integration/test_integration_once_id.py
+++ b/tests/integration/test_integration_once_id.py
@@ -32,7 +32,7 @@ def test_no_id(redis):
     except ValueError:
         pass
 
-def test_no_id(redis):
+def test_empty_string_id(redis):
     try:
         example.apply_async(args=(redis, ), task_id='')
         pytest.fail("QueueOnceId was started without a specified task_id")

--- a/tests/integration/test_integration_once_id.py
+++ b/tests/integration/test_integration_once_id.py
@@ -1,0 +1,82 @@
+from celery import Celery
+from celery.result import AsyncResult
+from celery_once import QueueOnce, AlreadyQueued
+from celery_once.tasks import QueueOnceId
+from freezegun import freeze_time
+import pytest
+
+
+app = Celery()
+app.conf.ONCE_REDIS_URL = 'redis://localhost:1337/0'
+app.conf.ONCE_DEFAULT_TIMEOUT = 30 * 60
+app.conf.CELERY_ALWAYS_EAGER = True
+
+
+@app.task(name="example", base=QueueOnceId)
+def example(redis, a=1):
+    return 'Something'
+
+@app.task(name="example_graceful", base=QueueOnceId, once={'graceful': True})
+def example_graceful(redis, a=1):
+    return 'Something'
+
+def helper_test_result(result, id='test'):
+    assert result is not None
+    assert isinstance(result, AsyncResult)
+    assert result.id == id
+
+def test_no_id(redis):
+    try:
+        example.apply_async(args=(redis, ))
+        pytest.fail("QueueOnceId was started without a specified task_id")
+    except ValueError:
+        pass
+
+def test_no_id_delay(redis):
+    try:
+        example.delay(redis, 1)
+        pytest.fail("QueueOnceId was started without a specified task_id")
+    except ValueError:
+        pass
+
+def test_specified_num_id(redis):
+    result = example.apply_async(args=(redis, ), task_id=1)
+    helper_test_result(result, id=1)
+
+def test_specified_string_id(redis):
+    result = example.apply_async(args=(redis, ), task_id='test')
+    helper_test_result(result)
+
+def test_specified_id_exists(redis):
+    redis.set("qo_example_graceful_test", 10000000000)
+    result = example_graceful.apply_async(args=(redis, ), task_id='test')
+    helper_test_result(result)
+
+def test_specified_id_exists_not_graceful(redis):
+    redis.set("qo_example_test", 10000000000)
+    try:
+        example.apply_async(args=(redis, ), task_id='test')
+        pytest.fail("QueueOnceId should have failed")
+    except AlreadyQueued:
+        pass
+
+@freeze_time("2012-01-14")  # 1326499200
+def test_apply_async_timeout_fail(redis):
+    try:
+        redis.set("qo_example_test", 1326499200 + 10 * 60)
+        example.apply_async(args=(redis, ), task_id='test')
+        pytest.fail("QueueOnceId should have failed")
+    except AlreadyQueued:
+        pass
+
+@freeze_time("2012-01-14")  # 1326499200
+def test_apply_async_timeout(redis):
+    redis.set("qo_example_test", 1326499200 - 60 * 60)
+    result = example.apply_async(args=(redis, ), task_id='test')
+    helper_test_result(result)
+
+@freeze_time("2012-01-14")  # 1326499200
+def test_apply_async_timeout_result(redis):
+    redis.set("qo_example_graceful_test", 1326499200 + 10 * 60)
+    result = example_graceful.apply_async(args=(redis, ), task_id='test')
+    helper_test_result(result)

--- a/tests/integration/test_integration_once_id.py
+++ b/tests/integration/test_integration_once_id.py
@@ -32,6 +32,13 @@ def test_no_id(redis):
     except ValueError:
         pass
 
+def test_no_id(redis):
+    try:
+        example.apply_async(args=(redis, ), task_id='')
+        pytest.fail("QueueOnceId was started without a specified task_id")
+    except ValueError:
+        pass
+
 def test_no_id_delay(redis):
     try:
         example.delay(redis, 1)

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -81,7 +81,7 @@ def task_id_example(a, b):
     return a + b
 
 def test_task_id_key():
-    assert "qo_task_id_example_a_key" == task_id_example.get_key(task_id='a_key')
+    assert "qo_task_id_example_a_key" == task_id_example.get_key_from_id(task_id='a_key')
 
 def test_task_id_key_num():
-    assert "qo_task_id_example_10" == task_id_example.get_key(task_id=10)
+    assert "qo_task_id_example_10" == task_id_example.get_key_from_id(task_id=10)

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,5 +1,5 @@
 from celery import task
-from celery_once.tasks import QueueOnce, AlreadyQueued
+from celery_once.tasks import QueueOnce, AlreadyQueued, QueueOnceId
 from freezegun import freeze_time
 import pytest
 
@@ -75,3 +75,13 @@ def test_clear_lock(redis):
     assert redis.get("test") is None
 
 
+# QueueOnceId
+@task(name='task_id_example', base=QueueOnceId, once={'keys': ['a']})
+def task_id_example(a, b):
+    return a + b
+
+def test_task_id_key():
+    assert "qo_task_id_example_a_key" == task_id_example.get_key(task_id='a_key')
+
+def test_task_id_key_num():
+    assert "qo_task_id_example_10" == task_id_example.get_key(task_id=10)


### PR DESCRIPTION
I worked on a feature to prevent tasks with the same id to run at the same time. Celery does not have protection against this. If you run two same tasks with the same id, both will equally be processed.
I think this use case is not so common but it is critical in my new project. 

Apart from integrity, the main reason for this is the possibility to retrieve the AsyncResult of the running task and use that to listen to its execution and/or get its result.

Apart from me, I could find at least another interested user.
http://stackoverflow.com/questions/27771229/reuse-results-for-celery-tasks

I have extended celery_once since the idea behind is just the same. 

I created a completely new task QueueOnceId type because I think that the variety of parameters of QueueOnce do not really apply well to QueueOnceId, so in order to avoid confusion I separated them. 
Also, mixing the two would change the behavior of QueueOnce but it can be done. I have already done some prototyping where QueueOnce has a new failure type so no need for a new task. If you prefer that way, just tell me and I will work on it.